### PR TITLE
Fixed: phpunit/phpunit placement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "doctrine/orm": "^2.6",
-        "phpunit/phpunit": "^8.2",
         "symfony/property-access": "^4.3",
         "thecodingmachine/safe": "^0.1.15"
     },
@@ -20,6 +19,7 @@
         "localheinz/composer-normalize": "^1.2",
         "phpstan/phpstan": "^0.11.8",
         "phpstan/phpstan-strict-rules": "^0.11.1",
+        "phpunit/phpunit": "^8.2",
         "symplify/easy-coding-standard": "^6.0",
         "thecodingmachine/phpstan-safe-rule": "^0.1.3"
     },


### PR DESCRIPTION
Package `phpunit/phpunit` should be at require-dev section, otherwise it will conflict with other libs/projects which uses another version of phpunit.