### PR TITLE
Allow Symfony 7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
+                    - "8.2"
+                    - "8.3"
+                    - "8.4"
+                    - "8.5"
 
                 dependencies:
                     - "highest"
@@ -57,10 +60,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
-                    - "8.0"
-                    - "8.1"
                     - "8.2"
+                    - "8.3"
+                    - "8.4"
+                    - "8.5"
 
                 dependencies:
                     - "highest"
@@ -96,10 +99,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
-                    - "8.0"
-                    - "8.1"
                     - "8.2"
+                    - "8.3"
+                    - "8.4"
+                    - "8.5"
 
                 dependencies:
                     - "highest"
@@ -131,10 +134,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
-                    - "8.0"
-                    - "8.1"
                     - "8.2"
+                    - "8.3"
+                    - "8.4"
+                    - "8.5"
 
                 dependencies:
                     - "lowest"
@@ -167,8 +170,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
-                    - "8.0"
+                    - "8.2"
+                    - "8.3"
+                    - "8.4"
+                    - "8.5"
 
                 dependencies:
                     - "highest"

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.2",
         "doctrine/collections": "^1.6 || ^2.0",
         "doctrine/orm": "^2.8 || ^3.0",
         "doctrine/persistence": "^1.3 || ^2.1 || ^3.0",
-        "symfony/property-access": "^5.4 || ^6.0",
+        "symfony/property-access": "^5.4 || ^6.4 || ^7.4 || ^8.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
@@ -23,7 +23,7 @@
         "phpunit/phpunit": "^9.5.10",
         "psalm/plugin-phpunit": "^0.19.0",
         "setono/code-quality-pack": "^2.1.3",
-        "symfony/cache": "^5.4 || ^6.0",
+        "symfony/cache": "^5.4 || ^6.4 || ^7.4 || ^8.0",
         "weirdan/doctrine-psalm-plugin": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "psalm/plugin-phpunit": "^0.19.0",
         "setono/code-quality-pack": "^2.1.3",
         "symfony/cache": "^5.4 || ^6.4 || ^7.4 || ^8.0",
+        "symfony/var-exporter": "^5.4 || ^6.4 || ^7.4",
         "weirdan/doctrine-psalm-plugin": "^2.0"
     },
     "autoload": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,4 +16,20 @@
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
         <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <file name="src/Exception/LowerBoundIsGreaterThanUpperBoundException.php"/>
+                <file name="src/Exception/NoManagerException.php"/>
+                <file name="src/Factory/BatcherFactoryInterface.php"/>
+                <file name="src/Query/QueryRebuilderInterface.php"/>
+                <file name="tests/Entity/Entity.php"/>
+            </errorLevel>
+        </PossiblyUnusedMethod>
+        <UnusedClass>
+            <errorLevel type="suppress">
+                <file name="src/Query/QueryRebuilder.php"/>
+            </errorLevel>
+        </UnusedClass>
+    </issueHandlers>
 </psalm>

--- a/src/Batch/Batch.php
+++ b/src/Batch/Batch.php
@@ -27,16 +27,19 @@ abstract class Batch implements BatchInterface
         $this->parameters = $qb->getParameters()->toArray();
     }
 
+    #[\Override]
     public function getClass(): string
     {
         return $this->class;
     }
 
+    #[\Override]
     public function getDql(): string
     {
         return $this->dql;
     }
 
+    #[\Override]
     public function getParameters(): array
     {
         return $this->parameters;

--- a/src/Batch/CollectionBatch.php
+++ b/src/Batch/CollectionBatch.php
@@ -22,6 +22,7 @@ final class CollectionBatch extends Batch implements CollectionBatchInterface
         parent::__construct($qb);
     }
 
+    #[\Override]
     public function getCollection(): array
     {
         return $this->collection;

--- a/src/Batch/RangeBatch.php
+++ b/src/Batch/RangeBatch.php
@@ -33,11 +33,13 @@ final class RangeBatch extends Batch implements RangeBatchInterface
         parent::__construct($qb);
     }
 
+    #[\Override]
     public function getLowerBound(): int
     {
         return $this->lowerBound;
     }
 
+    #[\Override]
     public function getUpperBound(): int
     {
         return $this->upperBound;

--- a/src/Batcher/Batcher.php
+++ b/src/Batcher/Batcher.php
@@ -54,6 +54,7 @@ abstract class Batcher implements BatcherInterface
         ;
     }
 
+    #[\Override]
     public function getBatchCount(int $batchSize = 100): int
     {
         return (int) ceil($this->getCount() / $batchSize);

--- a/src/Batcher/Collection/CollectionBatcher.php
+++ b/src/Batcher/Collection/CollectionBatcher.php
@@ -10,6 +10,7 @@ use Setono\DoctrineORMBatcher\Batcher\Batcher;
 
 abstract class CollectionBatcher extends Batcher implements CollectionBatcherInterface
 {
+    #[\Override]
     protected function getBatchableQueryBuilder(): QueryBuilder
     {
         $qb = $this->getQueryBuilder();

--- a/src/Batcher/Collection/CollectionBatcherInterface.php
+++ b/src/Batcher/Collection/CollectionBatcherInterface.php
@@ -12,5 +12,6 @@ interface CollectionBatcherInterface extends BatcherInterface
     /**
      * @return iterable<CollectionBatchInterface>
      */
+    #[\Override]
     public function getBatches(int $batchSize = 100): iterable;
 }

--- a/src/Batcher/Collection/IdCollectionBatcher.php
+++ b/src/Batcher/Collection/IdCollectionBatcher.php
@@ -12,6 +12,7 @@ final class IdCollectionBatcher extends CollectionBatcher
     /**
      * @return iterable<CollectionBatchInterface>
      */
+    #[\Override]
     public function getBatches(int $batchSize = 100): iterable
     {
         $result = $this->getResult(sprintf('%s.%s', $this->alias, $this->identifier), $batchSize);

--- a/src/Batcher/Collection/ObjectCollectionBatcher.php
+++ b/src/Batcher/Collection/ObjectCollectionBatcher.php
@@ -12,6 +12,7 @@ final class ObjectCollectionBatcher extends CollectionBatcher
     /**
      * @return iterable<CollectionBatchInterface>
      */
+    #[\Override]
     public function getBatches(int $batchSize = 100): iterable
     {
         $result = $this->getResult(null, $batchSize);

--- a/src/Batcher/Range/IdRangeBatcher.php
+++ b/src/Batcher/Range/IdRangeBatcher.php
@@ -12,6 +12,7 @@ final class IdRangeBatcher extends RangeBatcher
     /**
      * @return iterable<RangeBatchInterface>
      */
+    #[\Override]
     public function getBatches(int $batchSize = 100): iterable
     {
         $result = $this->getResult(sprintf('%s.%s', $this->alias, $this->identifier), $batchSize);

--- a/src/Batcher/Range/NaiveIdRangeBatcher.php
+++ b/src/Batcher/Range/NaiveIdRangeBatcher.php
@@ -10,8 +10,6 @@ use Setono\DoctrineORMBatcher\Batch\RangeBatchInterface;
 
 final class NaiveIdRangeBatcher extends RangeBatcher implements NaiveIdRangeBatcherInterface
 {
-    private int $count;
-
     /**
      * @return iterable<RangeBatchInterface>
      */
@@ -46,10 +44,10 @@ final class NaiveIdRangeBatcher extends RangeBatcher implements NaiveIdRangeBatc
     {
         try {
             $bestPossibleCount = ($this->getMax() - $this->getMin()) + 1;
-        } catch (NoResultException $e) {
+        } catch (NoResultException) {
             return 0;
         }
 
-        return (int) round(($bestPossibleCount - $this->getCount()) / $bestPossibleCount * 100);
+        return (int) round((float) ($bestPossibleCount - $this->getCount()) / (float) $bestPossibleCount * 100.0);
     }
 }

--- a/src/Batcher/Range/NaiveIdRangeBatcher.php
+++ b/src/Batcher/Range/NaiveIdRangeBatcher.php
@@ -15,6 +15,7 @@ final class NaiveIdRangeBatcher extends RangeBatcher implements NaiveIdRangeBatc
     /**
      * @return iterable<RangeBatchInterface>
      */
+    #[\Override]
     public function getBatches(int $batchSize = 100): iterable
     {
         try {
@@ -40,6 +41,7 @@ final class NaiveIdRangeBatcher extends RangeBatcher implements NaiveIdRangeBatc
      * If the lowest id is 30 and the highest id is 190 the maximum number of rows is (190 - 30) + 1 = 161
      * If the number of rows is 145, then the sparseness is (161 - 145) / 161 * 100 = 9.94% and this method will return 10 in that case.
      */
+    #[\Override]
     public function getSparseness(): int
     {
         try {

--- a/src/Batcher/Range/RangeBatcher.php
+++ b/src/Batcher/Range/RangeBatcher.php
@@ -10,6 +10,7 @@ use Setono\DoctrineORMBatcher\Batcher\Batcher;
 
 abstract class RangeBatcher extends Batcher implements RangeBatcherInterface
 {
+    #[\Override]
     protected function getBatchableQueryBuilder(): QueryBuilder
     {
         $qb = $this->getQueryBuilder();

--- a/src/Batcher/Range/RangeBatcherInterface.php
+++ b/src/Batcher/Range/RangeBatcherInterface.php
@@ -12,5 +12,6 @@ interface RangeBatcherInterface extends BatcherInterface
     /**
      * @return iterable<RangeBatchInterface>
      */
+    #[\Override]
     public function getBatches(int $batchSize = 100): iterable;
 }

--- a/src/Factory/BatcherFactory.php
+++ b/src/Factory/BatcherFactory.php
@@ -31,6 +31,7 @@ final class BatcherFactory implements BatcherFactoryInterface
         $this->idRangeBatcherClass = $idRangeBatcherClass;
     }
 
+    #[\Override]
     public function createObjectCollectionBatcher(
         QueryBuilder $qb,
         string $identifier = 'id',
@@ -39,6 +40,7 @@ final class BatcherFactory implements BatcherFactoryInterface
         return new $this->objectCollectionBatcherClass($qb, $identifier, $clearOnBatch);
     }
 
+    #[\Override]
     public function createIdCollectionBatcher(
         QueryBuilder $qb,
         string $identifier = 'id',
@@ -47,6 +49,7 @@ final class BatcherFactory implements BatcherFactoryInterface
         return new $this->idCollectionBatcherClass($qb, $identifier, $clearOnBatch);
     }
 
+    #[\Override]
     public function createIdRangeBatcher(
         QueryBuilder $qb,
         string $identifier = 'id',

--- a/src/Factory/BatcherFactory.php
+++ b/src/Factory/BatcherFactory.php
@@ -23,7 +23,7 @@ final class BatcherFactory implements BatcherFactoryInterface
         string $objectCollectionBatcherClass,
         string $idCollectionBatcherClass,
         string $naiveIdRangeBatcherClass,
-        string $idRangeBatcherClass
+        string $idRangeBatcherClass,
     ) {
         $this->objectCollectionBatcherClass = $objectCollectionBatcherClass;
         $this->idCollectionBatcherClass = $idCollectionBatcherClass;
@@ -35,7 +35,7 @@ final class BatcherFactory implements BatcherFactoryInterface
     public function createObjectCollectionBatcher(
         QueryBuilder $qb,
         string $identifier = 'id',
-        bool $clearOnBatch = true
+        bool $clearOnBatch = true,
     ): CollectionBatcherInterface {
         return new $this->objectCollectionBatcherClass($qb, $identifier, $clearOnBatch);
     }
@@ -44,7 +44,7 @@ final class BatcherFactory implements BatcherFactoryInterface
     public function createIdCollectionBatcher(
         QueryBuilder $qb,
         string $identifier = 'id',
-        bool $clearOnBatch = true
+        bool $clearOnBatch = true,
     ): CollectionBatcherInterface {
         return new $this->idCollectionBatcherClass($qb, $identifier, $clearOnBatch);
     }
@@ -54,7 +54,7 @@ final class BatcherFactory implements BatcherFactoryInterface
         QueryBuilder $qb,
         string $identifier = 'id',
         bool $clearOnBatch = true,
-        int $sparsenessThreshold = 5
+        int $sparsenessThreshold = 5,
     ): RangeBatcherInterface {
         /** @var NaiveIdRangeBatcherInterface $naiveIdBatcher */
         $naiveIdBatcher = new $this->naiveIdRangeBatcherClass($qb, $identifier, $clearOnBatch);

--- a/src/Query/QueryRebuilder.php
+++ b/src/Query/QueryRebuilder.php
@@ -20,6 +20,7 @@ final class QueryRebuilder implements QueryRebuilderInterface
         $this->managerRegistry = $managerRegistry;
     }
 
+    #[\Override]
     public function rebuild(BatchInterface $batch): Query
     {
         $manager = $this->getManager($batch->getClass());

--- a/tests/Batcher/Collection/IdCollectionBatcherTest.php
+++ b/tests/Batcher/Collection/IdCollectionBatcherTest.php
@@ -57,7 +57,7 @@ final class IdCollectionBatcherTest extends EntityManagerAwareTestCase
 
         $batches = $batcher->getBatches(10);
 
-        foreach ($batches as $idx => $batch) {
+        foreach ($batches as $batch) {
             foreach ($batch->getCollection() as $id) {
                 $this->assertArrayHasKey($id, $expectedIds);
 

--- a/tests/Batcher/Collection/ObjectCollectionBatcherTest.php
+++ b/tests/Batcher/Collection/ObjectCollectionBatcherTest.php
@@ -57,7 +57,7 @@ final class ObjectCollectionBatcherTest extends EntityManagerAwareTestCase
 
         $batches = $batcher->getBatches(10);
 
-        foreach ($batches as $idx => $batch) {
+        foreach ($batches as $batch) {
             /** @var Entity $entity */
             foreach ($batch->getCollection() as $entity) {
                 $this->assertArrayHasKey($entity->getId(), $expectedIds);

--- a/tests/EntityManagerAwareTestCase.php
+++ b/tests/EntityManagerAwareTestCase.php
@@ -19,6 +19,7 @@ abstract class EntityManagerAwareTestCase extends TestCase
 
     protected ORMPurger $purger;
 
+    #[\Override]
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Factory/BatcherFactoryTest.php
+++ b/tests/Factory/BatcherFactoryTest.php
@@ -21,16 +21,19 @@ final class BatcherFactoryTest extends EntityManagerAwareTestCase
         $qb = $this->createQb();
 
         $cls = new class() implements NaiveIdRangeBatcherInterface {
+            #[\Override]
             public function getSparseness(): int
             {
                 return 1;
             }
 
+            #[\Override]
             public function getBatches(int $batchSize = 100): iterable
             {
                 return [];
             }
 
+            #[\Override]
             public function getBatchCount(int $batchSize = 100): int
             {
                 return 0;
@@ -52,16 +55,19 @@ final class BatcherFactoryTest extends EntityManagerAwareTestCase
         $qb = $this->createQb();
 
         $naiveIdBatcher = new class() implements NaiveIdRangeBatcherInterface {
+            #[\Override]
             public function getSparseness(): int
             {
                 return 6;
             }
 
+            #[\Override]
             public function getBatches(int $batchSize = 100): iterable
             {
                 return [];
             }
 
+            #[\Override]
             public function getBatchCount(int $batchSize = 100): int
             {
                 return 0;
@@ -74,11 +80,13 @@ final class BatcherFactoryTest extends EntityManagerAwareTestCase
                 return 6;
             }
 
+            #[\Override]
             public function getBatches(int $batchSize = 100): iterable
             {
                 return [];
             }
 
+            #[\Override]
             public function getBatchCount(int $batchSize = 100): int
             {
                 return 0;


### PR DESCRIPTION
The minimum required PHP version is now 8.2, as stated in the supported PHP versions.